### PR TITLE
update recipe to use latest osx-arm build

### DIFF
--- a/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:

--- a/README.md
+++ b/README.md
@@ -247,6 +247,3 @@ Feedstock Maintainers
 * [@marcelotrevisani](https://github.com/marcelotrevisani/)
 * [@ngam](https://github.com/ngam/)
 
-
-<!-- dummy commit to enable rerendering -->
-

--- a/README.md
+++ b/README.md
@@ -247,3 +247,6 @@ Feedstock Maintainers
 * [@marcelotrevisani](https://github.com/marcelotrevisani/)
 * [@ngam](https://github.com/ngam/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+# applicable metal framework only after 11: 
+# see this: https://github.com/phracker/MacOSX-SDKs/search?q=%3CMetal%2FMTLBlitCommandEncoder.h%3E
+# also some symbols only available after 11.0
+# Please consult conda-forge/core before doing this
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+  - "11.0"                 # [osx and x86_64]
+MACOSX_SDK_VERSION:        # [osx and x86_64]
+  - "11.0"                 # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d950c5d159c1345d0727dfb3cabb456e6947a8cb80519feaeed8e0b35e6e913e
 
 build:
-  number: 2
+  number: 3
   script:
     - cd python
     - {{ PYTHON }} -m pip install . -vv
@@ -54,6 +54,7 @@ requirements:
     - cloudpickle
     - tornado
     - synr  ==0.5.0
+    - pytest
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d950c5d159c1345d0727dfb3cabb456e6947a8cb80519feaeed8e0b35e6e913e
 
 build:
-  number: 1
+  number: 2
   script:
     - cd python
     - {{ PYTHON }} -m pip install . -vv
@@ -29,7 +29,6 @@ requirements:
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - cython                                 # [build_platform != target_platform]
     - numpy                                  # [build_platform != target_platform]
-
   host:
     - libtvm =={{ version }}=*{{ proc_type }}*
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ requirements:
 
 test:
   imports:
-    - tvm
+    - tvm  # [not osx]
   requires:
    - pip
    - pytest
@@ -66,7 +66,7 @@ test:
     - tests
   commands:
    - pip check
-   - python -m pytest -v tests/python/all-platform-minimal-test
+   - python -m pytest -v tests/python/all-platform-minimal-test  # [not osx]
 
 about:
   home: https://tvm.apache.org/


### PR DESCRIPTION
Hi! This is the friendly automated conda-forge-webservice.

I've rerendered the recipe as instructed in #21.


Here's a checklist to do before merging.
- [x] Bump the build number if needed.
- [x] check if `hdf7b55d_3_cpu` is the osx-arm hash for libtvm

Fixes #21